### PR TITLE
Refactor to use the sdc_aws_utils python library and remove redundent code (v2)

### DIFF
--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -1,5 +1,5 @@
 # Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
-FROM public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest
+FROM public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
 
 # Working Directory Arguments
 ARG ROOT="/"
@@ -17,34 +17,23 @@ RUN pip install -r requirements.txt
 WORKDIR ${FUNCTION_DIR}
 
 # Set Up Lambda Runtime Environment
-RUN curl -Lo /usr/local/bin/aws-lambda-rie \
+RUN apt-get install -y curl && curl -Lo /usr/local/bin/aws-lambda-rie \
     https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie && \
     chmod +x /usr/local/bin/aws-lambda-rie
 
 # Copy files from the source folder
 COPY src/. ${FUNCTION_DIR}
 
-# Change name of file processor module in container
-RUN mv file_processor dev_file_processor \
-    && ls
+# Set permissions for all files in function directory
+RUN chmod -R 755 ${FUNCTION_DIR}
+RUN chown -R 1000:1000 ${FUNCTION_DIR}
 
 # Copy entry script into function director (Script is used distinguish dev/production mode)
 COPY entry_script.sh ${FUNCTION_DIR}
 
-# Change working directory to root
-WORKDIR ${ROOT}
-
-# Pull the latest official release of repo and copy it's file processor module into function directory
-RUN git clone https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git --branch $(git -c 'versionsort.suffix=-' \
-ls-remote --exit-code --refs --sort='version:refname' --tags https://github.com/HERMES-SOC/sdc_aws_processing_lambda.git \
-'*' | tail --lines=1 | cut --delimiter='/' --fields=3)
-
-# Change rights on folder
-RUN chmod -R 777 sdc_aws_processing_lambda
-
-# Copy file_processor module from release to module
-RUN cd sdc_aws_processing_lambda/lambda_function/src \
-    && cp -r file_processor /lambda_function/
+# Set permissions for entry script
+RUN chmod 755 ${FUNCTION_DIR}entry_script.sh
+RUN chown 1000:1000 ${FUNCTION_DIR}entry_script.sh
 
 # Change working directory to /function
 WORKDIR ${FUNCTION_DIR}

--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -1,7 +1,7 @@
 # Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
 ARG BASE_IMAGE=public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
 
-FROM BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 # Working Directory Arguments
 ARG ROOT="/"

--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -1,5 +1,7 @@
 # Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
-FROM public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
+ARG BASE_IMAGE=public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest
+
+FROM BASE_IMAGE
 
 # Working Directory Arguments
 ARG ROOT="/"

--- a/lambda_function/requirements.txt
+++ b/lambda_function/requirements.txt
@@ -1,10 +1,5 @@
+sdc_aws_utils @ git+https://github.com/HERMES-SOC/sdc_aws_utils.git
 hermes_spani @ git+https://github.com/HERMES-SOC/hermes_spani.git
 hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git
 hermes_nemisis @ git+https://github.com/HERMES-SOC/hermes_nemisis.git
 hermes_merit @ git+https://github.com/HERMES-SOC/hermes_merit.git
-pytest
-pytest-astropy 
-pytest-cov
-flake8 
-black
-slack_sdk

--- a/lambda_function/src/config.yaml
+++ b/lambda_function/src/config.yaml
@@ -4,13 +4,16 @@ MISSION_NAME: 'hermes'
 # Package name for mission 
 MISSION_PKG: 'hermes_core'
 
+# Incoming data bucket
+INCOMING_BUCKET: 'swsoc-incoming'
+
 # Instrument names used in the mission. 
 # The names are used to dynamically import the instrument packages.
 INSTR_NAMES: 
-- "eea"
-- "nemisis"
-- "merit"
-- "spani"
+- 'eea'
+- 'nemisis'
+- 'merit'
+- 'spani'
 
 # Timestream region
 TSD_REGION: 'us-east-1'

--- a/lambda_function/src/file_processor/file_processor.py
+++ b/lambda_function/src/file_processor/file_processor.py
@@ -240,25 +240,41 @@ class FileProcessor:
                             filename=new_file_path,
                             file_key=new_file_key,
                         )
-
-                        if self.slack_client:
-                            # Send Slack Notification
-                            send_pipeline_notification(
-                                slack_client=self.slack_client,
-                                slack_channel=self.slack_channel,
-                                path=new_file_path,
-                                alert_type="processed",
+                        try:
+                            if self.slack_client:
+                                # Send Slack Notification
+                                send_pipeline_notification(
+                                    slack_client=self.slack_client,
+                                    slack_channel=self.slack_channel,
+                                    path=new_file_path,
+                                    alert_type="processed",
+                                )
+                        except Exception as e:
+                            log.error(
+                                {
+                                    "status": "ERROR",
+                                    "message": f"Error when logging to Slack: {e}",
+                                }
                             )
-                        if self.timestream_client:
-                            # Log to timeseries database
-                            log_to_timestream(
-                                timestream_client=self.timestream_client,
-                                action_type="PUT",
-                                file_key=self.file_key,
-                                new_file_key=new_file_key,
-                                source_bucket=destination_bucket,
-                                destination_bucket=destination_bucket,
-                                environment=self.environment,
+
+                        try:
+                            if self.timestream_client:
+                                # Log to timeseries database
+                                log_to_timestream(
+                                    timestream_client=self.timestream_client,
+                                    action_type="PUT",
+                                    file_key=self.file_key,
+                                    new_file_key=new_file_key,
+                                    source_bucket=destination_bucket,
+                                    destination_bucket=destination_bucket,
+                                    environment=self.environment,
+                                )
+                        except Exception as e:
+                            log.error(
+                                {
+                                    "status": "ERROR",
+                                    "message": f"Error when logging to Timestream: {e}",
+                                }
                             )
 
                 except ValueError as e:

--- a/lambda_function/src/file_processor/file_processor.py
+++ b/lambda_function/src/file_processor/file_processor.py
@@ -240,41 +240,26 @@ class FileProcessor:
                             filename=new_file_path,
                             file_key=new_file_key,
                         )
-                        try:
-                            if self.slack_client:
-                                # Send Slack Notification
-                                send_pipeline_notification(
-                                    slack_client=self.slack_client,
-                                    slack_channel=self.slack_channel,
-                                    path=new_file_path,
-                                    alert_type="processed",
-                                )
-                        except Exception as e:
-                            log.error(
-                                {
-                                    "status": "ERROR",
-                                    "message": f"Error when logging to Slack: {e}",
-                                }
+
+                        if self.slack_client:
+                            # Send Slack Notification
+                            send_pipeline_notification(
+                                slack_client=self.slack_client,
+                                slack_channel=self.slack_channel,
+                                path=new_file_path,
+                                alert_type="processed",
                             )
 
-                        try:
-                            if self.timestream_client:
-                                # Log to timeseries database
-                                log_to_timestream(
-                                    timestream_client=self.timestream_client,
-                                    action_type="PUT",
-                                    file_key=self.file_key,
-                                    new_file_key=new_file_key,
-                                    source_bucket=destination_bucket,
-                                    destination_bucket=destination_bucket,
-                                    environment=self.environment,
-                                )
-                        except Exception as e:
-                            log.error(
-                                {
-                                    "status": "ERROR",
-                                    "message": f"Error when logging to Timestream: {e}",
-                                }
+                        if self.timestream_client:
+                            # Log to timeseries database
+                            log_to_timestream(
+                                timestream_client=self.timestream_client,
+                                action_type="PUT",
+                                file_key=self.file_key,
+                                new_file_key=new_file_key,
+                                source_bucket=destination_bucket,
+                                destination_bucket=destination_bucket,
+                                environment=self.environment,
                             )
 
                 except ValueError as e:

--- a/lambda_function/src/file_processor/file_processor.py
+++ b/lambda_function/src/file_processor/file_processor.py
@@ -3,61 +3,70 @@ This Module contains the FileProcessor class that will distinguish
 the appropriate HERMES intrument library to use when processing
 the file based off which bucket the file is located in.
 """
-import boto3
 import botocore
-from datetime import date, datetime
-import time
-import logging
-import yaml
 import os
 import os.path
-from pathlib import Path
-from slack_sdk import WebClient
+import json
 from slack_sdk.errors import SlackApiError
 
-# Initialize constants to be parsed from config.yaml
-MISSION_NAME = ""
-INSTR_NAMES = []
-MISSION_PKG = ""
+from sdc_aws_utils.logging import log, configure_logger
+from sdc_aws_utils.config import (
+    TSD_REGION,
+    INSTR_TO_PKG,
+    parser as science_filename_parser,
+    get_instrument_bucket,
+)
+from sdc_aws_utils.aws import (
+    create_s3_client_session,
+    create_timestream_client_session,
+    object_exists,
+    download_file_from_s3,
+    upload_file_to_s3,
+    log_to_timestream,
+    create_s3_file_key,
+)
+from sdc_aws_utils.slack import get_slack_client, send_pipeline_notification
 
-# Read YAML file and parse variables
-try:
-    with open("./config.yaml", "r") as f:
-        config = yaml.safe_load(f)
-        print("config.yaml loaded successfully")
-        MISSION_NAME = config["MISSION_NAME"]
-        INSTR_NAMES = config["INSTR_NAMES"]
-        MISSION_PKG = config["MISSION_PKG"]
-        TSD_REGION = config["TSD_REGION"]
-
-except FileNotFoundError:
-    print("config.yaml not found")
-    exit(1)
-
-
-# Initialize other constants after loading YAML file
-INSTR_PKG = [f"{MISSION_NAME}_{this_instr}" for this_instr in INSTR_NAMES]
-INSTR_TO_BUCKET_NAME = {
-    this_instr: f"{MISSION_NAME}-{this_instr}" for this_instr in INSTR_NAMES
-}
-INSTR_TO_PKG = dict(zip(INSTR_NAMES, INSTR_PKG))
+# Configure logger
+configure_logger()
 
 
-# Import logging from mission package
-mission_pkg = __import__(MISSION_PKG)
-log = getattr(mission_pkg, "log")
+def handle_event(event, context) -> dict:
+    """
+    Handles the event passed to the lambda function to initialize the FileProcessor
 
-# Import logging and util from mission package
-mission_pkg = __import__(MISSION_PKG)
-log = getattr(mission_pkg, "log")
-util = getattr(mission_pkg, "util").util
+    :param event: Event data passed from the lambda trigger
+    :type event: dict
+    :param context: Lambda context
+    :type context: dict
+    :return: Returns a 200 (Successful) / 500 (Error) HTTP response
+    :rtype: dict
+    """
+    try:
+        environment = os.getenv("LAMBDA_ENVIRONMENT", "DEVELOPMENT")
 
-# Starts boto3 session so it gets access to needed credentials
-session = boto3.Session(region_name=TSD_REGION)
+        # Check if SNS or S3 event
+        records = json.loads(event["Records"][0]["Sns"]["Message"])["Records"]
 
-# To remove boto3 noisy debug logging
-logging.getLogger("botocore").setLevel(logging.CRITICAL)
-logging.getLogger("boto3").setLevel(logging.CRITICAL)
+        # Parse message from SNS Notification
+        for s3_event in records:
+            # Extract needed information from event
+            s3_bucket = s3_event["s3"]["bucket"]["name"]
+            file_key = s3_event["s3"]["object"]["key"]
+
+            FileProcessor(
+                s3_bucket=s3_bucket, file_key=file_key, environment=environment
+            )
+
+            return {"statusCode": 200, "body": "File Processed Successfully"}
+
+    except Exception as e:
+        log.error({"status": "ERROR", "message": e})
+
+        return {
+            "statusCode": 500,
+            "body": json.dumps(f"Error Processing File: {e}"),
+        }
 
 
 class FileProcessor:
@@ -115,15 +124,34 @@ class FileProcessor:
         if self.dry_run:
             log.warning("Performing Dry Run - Files will not be copied/removed")
 
+        # Initialize S3 Client
+        self.s3_client = create_s3_client_session()
+
+        try:
+            # Initialize Timestream Client
+            self.timestream_client = create_timestream_client_session(TSD_REGION)
+
+        except botocore.exceptions.ClientError:
+            self.timestream_client = None
+            log.error(
+                {
+                    "status": "ERROR",
+                    "message": "Timestream Client could not be initialized",
+                }
+            )
+
         try:
             # Initialize the slack client
-            self.slack_client = WebClient(token=os.getenv("SLACK_TOKEN"))
+            self.slack_client = get_slack_client(
+                slack_token=os.getenv("SDC_AWS_SLACK_TOKEN")
+            )
 
             # Initialize the slack channel
-            self.slack_channel = os.getenv("SLACK_CHANNEL")
+            self.slack_channel = os.getenv("SDC_AWS_SLACK_CHANNEL")
 
         except SlackApiError as e:
             error_code = int(e.response["Error"]["Code"])
+            self.slack_client = None
             if error_code == 404:
                 log.error(
                     {
@@ -133,6 +161,7 @@ class FileProcessor:
                 )
 
         except Exception as e:
+            self.slack_client = None
             log.error(
                 {
                     "status": "ERROR",
@@ -153,8 +182,10 @@ class FileProcessor:
         """
         # Verify object exists in instrument bucket
         if (
-            self._does_object_exists(
-                bucket=self.instrument_bucket_name, file_key=self.file_key
+            object_exists(
+                s3_client=self.s3_client,
+                bucket=self.instrument_bucket_name,
+                file_key=self.file_key,
             )
             or self.dry_run
         ):
@@ -165,16 +196,18 @@ class FileProcessor:
 
                 # Download file from instrument bucket if not a dry run
                 if not self.dry_run:
-                    file_path = self._download_file(
+                    file_path = download_file_from_s3(
+                        self.s3_client,
                         self.instrument_bucket_name,
                         self.file_key,
                         parsed_file_key,
                     )
 
                 # Parse the science file name
-                science_file = util.parse_science_filename(parsed_file_key)
+                science_file = science_filename_parser(parsed_file_key)
                 this_instr = science_file["instrument"]
-                destination_bucket = INSTR_TO_BUCKET_NAME[this_instr]
+                destination_bucket = get_instrument_bucket(this_instr, self.environment)
+
                 log.info(
                     f"Destination Bucket Parsed Successfully: {destination_bucket}"
                 )
@@ -194,35 +227,39 @@ class FileProcessor:
                     new_file_path = calibration.process_file(file_path)[0].name
 
                     # Get new file key
-                    new_file_key = self._generate_file_key(new_file_path)
+                    new_file_key = create_s3_file_key(
+                        science_filename_parser, new_file_path
+                    )
 
                     # Upload file to destination bucket if not a dry run
                     if not self.dry_run:
                         # Upload file to destination bucket
-                        self._upload_file(
-                            new_file_path, destination_bucket, new_file_key
+                        upload_file_to_s3(
+                            s3_client=self.s3_client,
+                            destination_bucket=destination_bucket,
+                            filename=new_file_path,
+                            file_key=new_file_key,
                         )
 
                         if self.slack_client:
                             # Send Slack Notification
-                            self._send_slack_notification(
+                            send_pipeline_notification(
                                 slack_client=self.slack_client,
                                 slack_channel=self.slack_channel,
-                                slack_message=(
-                                    f"File ({new_file_path}) has "
-                                    "been successfully processed and "
-                                    f"uploaded to {destination_bucket}.",
-                                ),
+                                path=new_file_path,
+                                alert_type="processed",
                             )
-
-                        # Log to timeseries database
-                        self._log_to_timestream(
-                            action_type="PUT",
-                            file_key=self.file_key,
-                            new_file_key=new_file_key,
-                            source_bucket=destination_bucket,
-                            destination_bucket=destination_bucket,
-                        )
+                        if self.timestream_client:
+                            # Log to timeseries database
+                            log_to_timestream(
+                                timestream_client=self.timestream_client,
+                                action_type="PUT",
+                                file_key=self.file_key,
+                                new_file_key=new_file_key,
+                                source_bucket=destination_bucket,
+                                destination_bucket=destination_bucket,
+                                environment=self.environment,
+                            )
 
                 except ValueError as e:
                     log.error(e)
@@ -231,246 +268,10 @@ class FileProcessor:
                 log.error(f"Error Processing File: {e}")
                 if self.slack_client:
                     # Send Slack Notification
-                    self._send_slack_notification(
+                    send_pipeline_notification(
                         slack_client=self.slack_client,
                         slack_channel=self.slack_channel,
-                        slack_message=(
-                            f"Error Processing File ({new_file_path})"
-                            f"from {destination_bucket}.",
-                        ),
-                        alert_type="error",
+                        path=new_file_path,
+                        alert_type="processed_error",
                     )
                 raise e
-
-    @staticmethod
-    def _does_object_exists(bucket: str, file_key: str) -> bool:
-        """
-        Returns wether or not the file exists in the specified bucket
-
-        :param bucket: The name of the bucket
-        :type bucket: str
-        :param file_key: The name of the file
-        :type file_key: str
-        :return: True if the file exists, False if it does not
-        :rtype: bool
-        """
-        s3 = session.resource("s3")
-
-        try:
-            s3.Object(bucket, file_key).load()
-        except botocore.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                log.info(f"File {file_key} does not exist in Bucket {bucket}")
-                # The object does not exist.
-                return False
-            else:
-                # Something else has gone wrong.
-                raise
-        else:
-            log.info(f"File {file_key} already exists in Bucket {bucket}")
-            return True
-
-    @staticmethod
-    def _send_slack_notification(
-        slack_client,
-        slack_channel: str,
-        slack_message: str,
-        alert_type: str = "success",
-    ) -> None:
-        """
-        Function to send a Slack Notification
-        """
-        log.info(f"Sending Slack Notification to {slack_channel}")
-        try:
-            color = {
-                "success": "#2ecc71",
-                "error": "#ff0000",
-            }
-            ct = datetime.now()
-            ts = ct.strftime("%y-%m-%d %H:%M:%S")
-            slack_client.chat_postMessage(
-                channel=slack_channel,
-                text=f"{ts} - {slack_message}",
-                attachments=[
-                    {
-                        "color": color[alert_type],
-                        "blocks": [
-                            {
-                                "type": "section",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": f"{ts} - {slack_message}",
-                                },
-                            }
-                        ],
-                    }
-                ],
-            )
-
-        except SlackApiError as e:
-            log.error(
-                {"status": "ERROR", "message": f"Error sending Slack Notification: {e}"}
-            )
-
-    @staticmethod
-    def _generate_file_key(file_key) -> str:
-        """
-        Function to generate full s3 file key in the format:
-        {level}/{year}/{month}/{file_key}
-
-        :param file_key: The name of the file
-        :type file_key: str
-        :return: The full s3 file key
-        :rtype: str
-        """
-        try:
-            current_year = date.today().year
-            current_month = date.today().month
-            if current_month < 10:
-                current_month = f"0{current_month}"
-
-            science_file = util.parse_science_filename(file_key)
-
-            new_file_key = (
-                f"{science_file['level']}/{current_year}/{current_month}/{file_key}"
-            )
-
-            return new_file_key
-
-        except IndexError as e:
-            log.error({"status": "ERROR", "message": e})
-            raise e
-
-    @staticmethod
-    def _download_file(source_bucket: str, file_key: str, parsed_file_key: str) -> Path:
-        """
-        Function to download file from S3
-
-        :param source_bucket: The name of the source bucket
-        :type source_bucket: str
-        :param file_key: The name of the file
-        :type file_key: str
-        :param parsed_file_key: The name of the file
-        :type parsed_file_key: str
-        :return: The path to the downloaded file
-        :rtype: Path
-        """
-        try:
-            # Initialize S3 Client
-            log.info(f"Downloading file {file_key} from {source_bucket}")
-            s3 = session.client("s3")
-
-            # Create tmp directory in root of lambda
-            if not os.path.exists("/tmp"):
-                os.mkdir("/tmp")
-
-            # Download file to tmp directory
-            s3.download_file(source_bucket, file_key, f"/tmp/{parsed_file_key}")
-
-            log.info(f"File {file_key} Successfully Downloaded")
-
-            return Path(f"/tmp/{parsed_file_key}")
-
-        except botocore.exceptions.ClientError as e:
-            log.error({"status": "ERROR", "message": e})
-
-            raise e
-
-    @staticmethod
-    def _upload_file(filename: str, destination_bucket: str, file_key: str) -> None:
-        """
-        Function to upload file to S3
-
-        :param filename: The name of the file
-        :type filename: str
-        :param destination_bucket: The name of the destination bucket
-        :type destination_bucket: str
-        :param file_key: The name of the file
-        :type file_key: str
-        :return: None
-        :rtype: None
-        """
-        try:
-            # Initialize S3 Client
-            log.info(f"Uploading file {file_key} to {destination_bucket}")
-            s3 = session.client("s3")
-
-            # Upload file to destination bucket
-            s3.upload_file(f"/tmp/{filename}", destination_bucket, file_key)
-
-            log.info(f"File {file_key} Successfully Uploaded")
-
-        except botocore.exceptions.ClientError as e:
-            log.error({"status": "ERROR", "message": e})
-
-            raise e
-
-    @staticmethod
-    def _log_to_timestream(
-        action_type: str,
-        file_key: str,
-        new_file_key: str = None,
-        source_bucket: str = None,
-        destination_bucket: str = None,
-    ) -> None:
-        """
-        Function to log to Timestream
-
-        :param action_type: The type of action performed
-        :type action_type: str
-        :param file_key: The name of the file
-        :type file_key: str
-        :param new_file_key: The new name of the file
-        :type new_file_key: str
-        :param source_bucket: The name of the source bucket
-        :type source_bucket: str
-        :param destination_bucket: The name of the destination bucket
-        :type destination_bucket: str
-        :return: None
-        :rtype: None
-        """
-        log.info("Logging to Timestream")
-        CURRENT_TIME = str(int(time.time() * 1000))
-        try:
-            # Initialize Timestream Client
-            timestream = session.client("timestream-write")
-
-            if not source_bucket and not destination_bucket:
-                raise ValueError("A Source or Destination Buckets is required")
-
-            # Write to Timestream
-            timestream.write_records(
-                DatabaseName="sdc_aws_logs",
-                TableName="sdc_aws_s3_bucket_log_table",
-                Records=[
-                    {
-                        "Time": CURRENT_TIME,
-                        "Dimensions": [
-                            {"Name": "action_type", "Value": action_type},
-                            {
-                                "Name": "source_bucket",
-                                "Value": source_bucket or "N/A",
-                            },
-                            {
-                                "Name": "destination_bucket",
-                                "Value": destination_bucket or "N/A",
-                            },
-                            {"Name": "file_key", "Value": file_key},
-                            {
-                                "Name": "new_file_key",
-                                "Value": new_file_key or "N/A",
-                            },
-                        ],
-                        "MeasureName": "timestamp",
-                        "MeasureValue": str(datetime.utcnow().timestamp()),
-                        "MeasureValueType": "DOUBLE",
-                    },
-                ],
-            )
-
-            log.info((f"File {file_key} Successfully Logged to Timestream"))
-
-        except botocore.exceptions.ClientError as e:
-            log.error({"status": "ERROR", "message": e})
-
-            raise e

--- a/lambda_function/src/lambda.py
+++ b/lambda_function/src/lambda.py
@@ -2,28 +2,14 @@
 This module contains the handler function and the main function
 which contains the logicthat initializes the FileProcessor class
 in it's correct environment.
-
-TODO: Skeleton Code for initial repo, logic still needs to be
-implemented and docstrings expanded
 """
 
-import json
-import os
-import logging
-
-
-from file_processor.file_processor import FileProcessor, log  # noqa: E402
-
-# To remove boto3 noisy debug logging
-logging.getLogger("botocore").setLevel(logging.CRITICAL)
-logging.getLogger("boto3").setLevel(logging.CRITICAL)
+from file_processor import file_processor
 
 
 def handler(event, context) -> dict:
     """
-    This is the lambda handler function that passes variables to the function that
-    handles the logic that initializes the FileProcessor class in it's correct
-    environment.
+    This is the lambda handler function that acts as a proxy to the main function handle_event
 
     :param event: Event data passed from the lambda trigger
     :type event: dict
@@ -32,81 +18,5 @@ def handler(event, context) -> dict:
     :return: Returns a 200 (Successful) / 500 (Error) HTTP response
     :rtype: dict
     """
-    # Extract needed information from event
-    try:
-        environment = os.getenv("LAMBDA_ENVIRONMENT")
-        if environment is None:
-            environment = "DEVELOPMENT"
 
-        # Check if SNS or S3 event
-        records = json.loads(event["Records"][0]["Sns"]["Message"])["Records"]
-
-        # Parse message from SNS Notification
-        for s3_event in records:
-            # Extract needed information from event
-            s3_bucket = s3_event["s3"]["bucket"]["name"]
-            file_key = s3_event["s3"]["object"]["key"]
-
-            # / 500 (Error) HTTP response
-            response = environment_setup(
-                s3_bucket=s3_bucket, file_key=file_key, environment=environment
-            )
-
-            return response
-
-    except Exception as e:
-        # Pass required variables to sort function and returns a 200 (Successful)
-        # / 500 (Error) HTTP response
-        log.error({"status": "ERROR", "message": e})
-
-        return {
-            "statusCode": 500,
-            "body": json.dumps(f"Error Processing File: {e}"),
-        }
-
-
-def environment_setup(s3_bucket: str, file_key: str, environment: str) -> dict:
-    """
-    This is the main function that handles logic that initializes
-    the FileProcessor class in it's correct environment.
-
-    :param s3_bucket: The name of the S3 bucket the file is located in
-    :type s3_bucket: str
-    :param file_key: The name of the S3 object that is being processed
-    :type file_key: str
-    :param environment: The environment the FileProcessor is running in
-    :type environment: str
-    """
-
-    # Production (Official Release) Environment / Local Development
-    try:
-        log.info(f"Initializing FileProcessor - Environment: {environment}")
-        if environment == "Production":
-            # Initialize FileProcessor class
-            FileProcessor(
-                s3_bucket=s3_bucket, file_key=file_key, environment=environment
-            )
-
-        else:
-            # pylint: disable=import-outside-toplevel
-            from dev_file_processor.file_processor import (
-                FileProcessor as DevFileProcessor,
-            )
-
-            # Initialize FileProcessor class
-            DevFileProcessor(
-                s3_bucket=s3_bucket, file_key=file_key, environment=environment
-            )
-
-        return {
-            "statusCode": 200,
-            "body": json.dumps("File Processed Successfully"),
-        }
-
-    except Exception as e:
-        log.error({"status": "ERROR", "message": e})
-
-        return {
-            "statusCode": 500,
-            "body": json.dumps("Error Processing File"),
-        }
+    return file_processor.handle_event(event, context)

--- a/lambda_function/src/lambda.py
+++ b/lambda_function/src/lambda.py
@@ -9,7 +9,8 @@ from file_processor import file_processor
 
 def handler(event, context) -> dict:
     """
-    This is the lambda handler function that acts as a proxy to the main function handle_event
+    This is the lambda handler function that acts as a proxy
+    to the main function handle_event
 
     :param event: Event data passed from the lambda trigger
     :type event: dict


### PR DESCRIPTION
This PR updates the processing lambda function to use the new sdc_aws_utils (https://github.com/HERMES-SOC/sdc_aws_utils), which removes a lot of redundant tasks across the repos into one Python library that can be easily updated from one location. This includes logging, an aws timestream database, and sending Slack notifications. Simplifying the main `lambda_function.py` and moving that logic into `file_processor.py` file.

What changes:
- Switches to one consolidated logging initiated and configured in sdc_aws_utils
- Switches to use the consolidated Slack messaging, which will be updated to the new format
- Switches to use the consolidated timestream database logging
- Moves code from handler to main `file_processor.py`

**Two PRs additional PRs will follow from re-writing and breaking apart the stale PR** 
