### PR TITLE
Refactor to Use Mission Specific Requirement Files

### DIFF
--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -1,6 +1,6 @@
 name: Test Lambda Function Locally and Upload Artifacts
 
-on: [pull_request, pull_request_target]
+on: [pull_request]
 
 jobs:
   test-and-upload:
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes -e SWXSOC=processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -37,6 +37,9 @@ jobs:
         STATUS_CODE=$(echo $HTTP_STATUS | grep -oP '200')
         echo "Status Code: $STATUS_CODE"
 
+        # Show logs from the container
+        docker logs processing_lambda
+        
         # If the HTTP status code is 200, then the test is successful
         if [ "$STATUS_CODE" == "200" ]; then
           echo "Success: HTTP status is 200"
@@ -48,8 +51,7 @@ jobs:
           exit 1  # Exit with failure
         fi
 
-        # Show logs from the container
-        docker logs processing_lambda
+
     
     - name: Copy Processed Files from Container
       if: steps.test-lambda.outputs.test_success == 'true'

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes -e SWXSOC=processing_function:latest
+        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -n processing_lambda -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
+        docker run -d --name processing_lambda -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 

--- a/.github/workflows/calibration.yml
+++ b/.github/workflows/calibration.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run Lambda Docker Container
       run: |
-        docker run -d -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
+        docker run -d -n processing_lambda -p 9000:8080 -e USE_INSTRUMENT_TEST_DATA=True -e SWXSOC_MISSION=hermes processing_function:latest
         container_id=$(docker ps -qf "ancestor=processing_function:latest")
         echo "Container ID: $container_id"
 
@@ -47,6 +47,9 @@ jobs:
           echo "test_success=false" >> $GITHUB_OUTPUT
           exit 1  # Exit with failure
         fi
+
+        # Show logs from the container
+        docker logs processing_lambda
     
     - name: Copy Processed Files from Container
       if: steps.test-lambda.outputs.test_success == 'true'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,4 +31,6 @@ jobs:
     - name: Run tests
       run: |
         pytest --pyargs lambda_function --cov lambda_function/src
+      env:
+        SWXSOC_MISSION: hermes
 

--- a/lambda_function/Dockerfile
+++ b/lambda_function/Dockerfile
@@ -7,7 +7,11 @@ FROM ${BASE_IMAGE}
 ARG ROOT="/"
 ARG FUNCTION_DIR="/lambda_function/"
 
-COPY requirements.txt ${ROOT}
+# Set default values for requirements file
+ARG REQUIREMENTS_FILE="hermes-requirements.txt"
+
+# Copy requirements file to root directory
+COPY ${REQUIREMENTS_FILE} ${ROOT}requirements.txt 
 
 # Update pip and install setuptools
 RUN pip install --upgrade pip setuptools

--- a/lambda_function/hermes-requirements.txt
+++ b/lambda_function/hermes-requirements.txt
@@ -1,7 +1,5 @@
-spacepy==0.5.0
 sdc_aws_utils @ git+https://github.com/HERMES-SOC/sdc_aws_utils.git
 hermes_spani @ git+https://github.com/HERMES-SOC/hermes_spani.git
 hermes_eea @ git+https://github.com/HERMES-SOC/hermes_eea.git
 hermes_nemisis @ git+https://github.com/HERMES-SOC/hermes_nemisis.git
 hermes_merit @ git+https://github.com/HERMES-SOC/hermes_merit.git
-psycopg2-binary==2.9.7

--- a/lambda_function/padre-requirements.txt
+++ b/lambda_function/padre-requirements.txt
@@ -1,0 +1,3 @@
+sdc_aws_utils @ git+https://github.com/HERMES-SOC/sdc_aws_utils.git
+padre_meddea @ git+https://github.com/PADRESat/padre_meddea.git
+padre_sharp @ git+https://github.com/PADRESat/padre_sharp.git

--- a/lambda_function/src/file_processor/file_processor.py
+++ b/lambda_function/src/file_processor/file_processor.py
@@ -23,7 +23,7 @@ from sdc_aws_utils.aws import (
 )
 
 # Configure logger
-configure_logger()
+# configure_logger()
 
 
 def handle_event(event, context) -> dict:

--- a/lambda_function/src/file_processor/file_processor.py
+++ b/lambda_function/src/file_processor/file_processor.py
@@ -23,7 +23,7 @@ from sdc_aws_utils.aws import (
 )
 
 # Configure logger
-# configure_logger()
+configure_logger()
 
 
 def handle_event(event, context) -> dict:

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,6 +3,7 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
+from swxsoc import log
 
 
 os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
@@ -10,6 +11,8 @@ from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402
     FileProcessor,  # noqa: E402
 )  # noqa: E402
+
+log.enable_warnings_logging()
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -7,11 +7,12 @@ from swxsoc import log
 
 log.disable_warnings_logging()
 
+os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402
     FileProcessor,  # noqa: E402
+    configure_logger,  # noqa: E402
 )  # noqa: E402
-
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,7 +3,7 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
-import astropy.logger
+from astropy import log
 
 os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
@@ -11,7 +11,7 @@ from src.file_processor.file_processor import (  # noqa: E402
     FileProcessor,  # noqa: E402
 )  # noqa: E402
 
-astropy.logger.disable_warnings_logging()
+log.disable_warnings_logging()
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,7 +3,9 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
-# from swxsoc import log
+from swxsoc import log
+
+log.disable_warnings_logging()
 
 from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -41,7 +41,7 @@ def test_file_calibrate():
     calibrated_file_path = FileProcessor._calibrate_file(intrument, file_path)
 
     # Verify
-    assert calibrated_file_path == "hermes_eea_l1_20230211T000000_v1.0.0.cdf"
+    assert calibrated_file_path == "hermes_eea_l1_20000101T170901_v1.0.0.cdf"
 
     # Cleanup
     os.remove(Path(parent_dir, calibrated_file_path))
@@ -65,7 +65,7 @@ def test_file_calibrate_failure():
 def test_handle_event(s3):
     filename = "hermes_EEA_l0_2023042-000000_v0.bin"
     parent_dir = "lambda_function/tests/test_data"
-    calibrated_file_path = "hermes_eea_l1_20230211T000000_v1.0.0.cdf"
+    calibrated_file_path = "hermes_eea_l1_20000101T170901_v1.0.0.cdf"
     # Set the absolute path using file_path as string
     os.environ["SDC_AWS_FILE_PATH"] = f"lambda_function/tests/test_data/{filename}"
 

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,15 +3,16 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
-from astropy import log
+
 
 os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402
     FileProcessor,  # noqa: E402
+    configure_logger,  # noqa: E402
 )  # noqa: E402
 
-log.disable_warnings_logging()
+configure_logger()
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,8 +3,7 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
-from swxsoc import log
-
+import astropy.logger
 
 os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
@@ -12,7 +11,7 @@ from src.file_processor.file_processor import (  # noqa: E402
     FileProcessor,  # noqa: E402
 )  # noqa: E402
 
-log.enable_warnings_logging()
+astropy.logger.disable_warnings_logging()
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -3,16 +3,13 @@ import os
 import json
 from moto import mock_s3
 from pathlib import Path
+# from swxsoc import log
 
-
-os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402
     FileProcessor,  # noqa: E402
-    configure_logger,  # noqa: E402
 )  # noqa: E402
 
-configure_logger()
 
 
 @pytest.fixture

--- a/lambda_function/tests/test_processor.py
+++ b/lambda_function/tests/test_processor.py
@@ -5,13 +5,12 @@ from moto import mock_s3
 from pathlib import Path
 from swxsoc import log
 
-log.disable_warnings_logging()
+log.disable_warnings_logging()  # noqa: E402
 
 os.environ["SDC_AWS_CONFIG_FILE_PATH"] = "lambda_function/src/config.yaml"
 from src.file_processor.file_processor import (  # noqa: E402
     handle_event,  # noqa: E402
     FileProcessor,  # noqa: E402
-    configure_logger,  # noqa: E402
 )  # noqa: E402
 
 


### PR DESCRIPTION
This refactors the function to use mission-specific requirements files, avoiding the need to install all instrument packages for every mission during the build. Including all instrument packages in the mission's base Docker image could lead to conflicts with development environment branches.

Included in this PR:
- Updates some tests for the generic swxsoc integration
- Linting
- Also only keeps calibration on pull_request and not pull_request_target since it is redundent and only tests against the main repo